### PR TITLE
Refactor styled components

### DIFF
--- a/src/ts/components/Welcome.tsx
+++ b/src/ts/components/Welcome.tsx
@@ -9,7 +9,7 @@ import { saveSettings } from '../background/store/settings'
 import { ThemeTypes } from './styles/themes'
 import ImageMapper from 'react-image-mapper'
 import { withRouter, RouteComponentProps } from 'react-router'
-import { LayoutContainer } from './basic-components'
+import { LayoutContainer, Section, Title } from './basic-components'
 
 interface IWelcomeProp extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -51,11 +51,11 @@ class Welcome extends React.Component<IWelcomeProp, IWelcomeState> {
           <Title>
             {t('pickColorTitle')}
           </Title>
-          <Text>
+          <Section>
             {t('pickColorDescription')}
-          </Text>
-          <Text>Click above to change color. Current color: {this.props.settings.color}</Text>
-          <Text>{t('speckleIntroduction')}</Text>
+          </Section>
+          <Section>Click above to change color. Current color: {this.props.settings.color}</Section>
+          <Section>{t('speckleIntroduction')}</Section>
         </LayoutContainer>
     )
   }
@@ -67,31 +67,11 @@ const LogoContainer = styled(Image)`
     height: 65px;
     object-fit: contain;
 `
+
 const ColorPickerContainer = styled('div')`
     width:208px;
     height: 208px;
     margin: 0 auto 68px;
-`
-const Text = styled.p`
-    width: 327px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    text-align: center;
-    color: #3e5860;
-`
-const Title = styled(Text)`
-    width: 311px;
-    height: 26px;
-    font-size: 19px;
-    font-weight: bold;
-    color: #30383B;
 `
 
 const mapStateToProps = (state: IAppState) => {

--- a/src/ts/components/Welcome.tsx
+++ b/src/ts/components/Welcome.tsx
@@ -9,6 +9,7 @@ import { saveSettings } from '../background/store/settings'
 import { ThemeTypes } from './styles/themes'
 import ImageMapper from 'react-image-mapper'
 import { withRouter, RouteComponentProps } from 'react-router'
+import { LayoutContainer } from './basic-components'
 
 interface IWelcomeProp extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -38,7 +39,7 @@ class Welcome extends React.Component<IWelcomeProp, IWelcomeState> {
 
   render () {
     return (
-       <WelcomeContainer>
+       <LayoutContainer>
          <LogoContainer><Image src='/assets/logo-3-x.svg' /></LogoContainer>
          <ColorPickerContainer><ImageMapper
             src={'/assets/icon-dots.svg'}
@@ -50,29 +51,16 @@ class Welcome extends React.Component<IWelcomeProp, IWelcomeState> {
           <Title>
             {t('pickColorTitle')}
           </Title>
-
           <Text>
             {t('pickColorDescription')}
           </Text>
-
           <Text>Click above to change color. Current color: {this.props.settings.color}</Text>
-
           <Text>{t('speckleIntroduction')}</Text>
-
-        </WelcomeContainer>
+        </LayoutContainer>
     )
   }
 }
 
-const WelcomeContainer = styled('div')`
-    text-align: center;
-    width: 375px;
-    height: 667px;
-    border-radius: 4px;
-    box-shadow: 0 6px 30px 0 rgba(0, 0, 0, 0.08);
-    border: solid 1px #e7e7e7;
-    background-color: #ffffff;
-`
 const LogoContainer = styled(Image)`
     margin: 36px auto 68px;
     width: 150px;

--- a/src/ts/components/account/ConfirmPhrase.tsx
+++ b/src/ts/components/account/ConfirmPhrase.tsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux'
 import { Message, List } from 'semantic-ui-react'
 import { createAccount } from '../../services/keyring-vault-proxy'
 import { DEFAULT_ROUTE } from '../../constants/routes'
+import { Button } from '../basic-components'
 
 interface IConfirmPhraseProps extends StateProps, RouteComponentProps {}
 
@@ -81,9 +82,9 @@ class ConfirmPhrase extends React.Component<IConfirmPhraseProps, IConfirmPhraseS
           </Message>
 
           <Text>
-            <StyledButton onClick={this.createAccount} disabled={!this.isPhraseConfirmed()}>
+            <Button onClick={this.createAccount} disabled={!this.isPhraseConfirmed()}>
               {t('confirmPhraseButton')}
-            </StyledButton>
+            </Button>
           </Text>
 
         </div>
@@ -125,22 +126,6 @@ const MnemonicPad = styled.textarea`
   line-height: 1.57;
   letter-spacing: normal;
   color: #30383b;
-`
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
 `
 const error = {
   width: 311,

--- a/src/ts/components/account/ConfirmPhrase.tsx
+++ b/src/ts/components/account/ConfirmPhrase.tsx
@@ -76,9 +76,11 @@ class ConfirmPhrase extends React.Component<IConfirmPhraseProps, IConfirmPhraseS
             <List horizontal={true} items={this.state.wordList} />
           </Section>
 
-          <Message negative={true} hidden={!this.state.errorMessage} style={error}>
-            {this.state.errorMessage}
-          </Message>
+          <Section>
+            <Message negative={true} hidden={!this.state.errorMessage}>
+              {this.state.errorMessage}
+            </Message>
+          </Section>
 
           <Section>
             <Button onClick={this.createAccount} disabled={!this.isPhraseConfirmed()}>
@@ -99,10 +101,5 @@ const mapStateToProps = (state: IAppState) => {
 }
 
 type StateProps = ReturnType<typeof mapStateToProps>
-
-const error = {
-  width: 311,
-  margin: 'auto'
-}
 
 export default withRouter(connect(mapStateToProps)(ConfirmPhrase))

--- a/src/ts/components/account/ConfirmPhrase.tsx
+++ b/src/ts/components/account/ConfirmPhrase.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import styled from 'styled-components'
 import t from '../../services/i18n'
 import Progress from './Progress'
 import { IAppState } from '../../background/store/all'
@@ -8,7 +7,7 @@ import { connect } from 'react-redux'
 import { Message, List } from 'semantic-ui-react'
 import { createAccount } from '../../services/keyring-vault-proxy'
 import { DEFAULT_ROUTE } from '../../constants/routes'
-import { Button } from '../basic-components'
+import { Button, Section, MnemonicPad } from '../basic-components'
 
 interface IConfirmPhraseProps extends StateProps, RouteComponentProps {}
 
@@ -68,24 +67,24 @@ class ConfirmPhrase extends React.Component<IConfirmPhraseProps, IConfirmPhraseS
         <div>
           <Progress color={this.props.settings.color} progress={2} />
 
-          <Text>
+          <Section>
             <div>{t('phraseConfirmTitle')}</div>
             <MnemonicPad value={this.state.inputPhrase} onChange={this.changePhrase}/>
-          </Text>
+          </Section>
 
-          <Text>
+          <Section>
             <List horizontal={true} items={this.state.wordList} />
-          </Text>
+          </Section>
 
           <Message negative={true} hidden={!this.state.errorMessage} style={error}>
             {this.state.errorMessage}
           </Message>
 
-          <Text>
+          <Section>
             <Button onClick={this.createAccount} disabled={!this.isPhraseConfirmed()}>
               {t('confirmPhraseButton')}
             </Button>
-          </Text>
+          </Section>
 
         </div>
     )
@@ -101,32 +100,6 @@ const mapStateToProps = (state: IAppState) => {
 
 type StateProps = ReturnType<typeof mapStateToProps>
 
-const Text = styled.div`
-    width: 327px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    color: #3e5860;
-`
-const MnemonicPad = styled.textarea`
-  width: 311px;
-  height: 125px;
-  font-family: Nunito;
-  padding: 10px;
-  font-size: 14px;
-  font-weight: normal;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.57;
-  letter-spacing: normal;
-  color: #30383b;
-`
 const error = {
   width: 311,
   margin: 'auto'

--- a/src/ts/components/account/CreatePassword.tsx
+++ b/src/ts/components/account/CreatePassword.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import styled from 'styled-components'
 import t from '../../services/i18n'
 import Progress from './Progress'
 import { IAppState } from '../../background/store/all'
@@ -9,7 +8,7 @@ import { Message } from 'semantic-ui-react'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { GENERATE_PHRASE_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
-import { Button, Section } from '../basic-components'
+import { Button, Section, StyledPassword } from '../basic-components'
 
 interface ICreatePasswordProps extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -66,7 +65,6 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
               value={this.state.newPassword}
               onChange={evt => this.setState({ newPassword: evt.target.value })}/>
           </Section>
-
           <Section>
             <StyledPassword
               type='password'
@@ -75,17 +73,17 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
               onChange={evt => this.setState({ confirmPassword: evt.target.value })}
               />
           </Section>
-
-          <Message negative={true} hidden={!this.state.errorMessage}>
-            {this.state.errorMessage}
-          </Message>
+          <Section>
+            <Message negative={true} hidden={!this.state.errorMessage}>
+              {this.state.errorMessage}
+            </Message>
+          </Section>
 
           <Section>
             <Button onClick={this.handleClick}>
               {t('Create Account')}
             </Button>
           </Section>
-
         </div>
     )
   }
@@ -103,10 +101,5 @@ const mapDispatchToProps = { setLocked }
 type StateProps = ReturnType<typeof mapStateToProps>
 
 type DispatchProps = typeof mapDispatchToProps
-
-const StyledPassword = styled.input`
-  width: 311px;
-  height: 42px;
-`
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CreatePassword))

--- a/src/ts/components/account/CreatePassword.tsx
+++ b/src/ts/components/account/CreatePassword.tsx
@@ -23,11 +23,21 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
   constructor (props: ICreatePasswordProps) {
     super(props)
     this.handleClick = this.handleClick.bind(this)
+    this.setNewPassword = this.setNewPassword.bind(this)
+    this.setConfirmPassword = this.setConfirmPassword.bind(this)
   }
 
   state: ICreatePasswordState = {
     newPassword: '',
     confirmPassword: ''
+  }
+
+  setNewPassword (event) {
+    this.setState({ ...this.state, newPassword: event.target.value })
+  }
+
+  setConfirmPassword (event) {
+    this.setState({ ...this.state, confirmPassword: event.target.value })
   }
 
   handleClick () {
@@ -63,15 +73,16 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
               type='password'
               placeholder={t('Create new password')}
               value={this.state.newPassword}
-              onChange={evt => this.setState({ newPassword: evt.target.value })}/>
+              onChange={this.setNewPassword}
+            />
           </Section>
           <Section>
             <StyledPassword
               type='password'
               placeholder={t('Repeat password')}
               value={this.state.confirmPassword}
-              onChange={evt => this.setState({ confirmPassword: evt.target.value })}
-              />
+              onChange={this.setConfirmPassword}
+            />
           </Section>
           <Section>
             <Message negative={true} hidden={!this.state.errorMessage}>

--- a/src/ts/components/account/CreatePassword.tsx
+++ b/src/ts/components/account/CreatePassword.tsx
@@ -9,6 +9,7 @@ import { Message } from 'semantic-ui-react'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { GENERATE_PHRASE_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
+import { Button } from '../basic-components'
 
 interface ICreatePasswordProps extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -19,6 +20,11 @@ interface ICreatePasswordState {
 }
 
 class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswordState> {
+
+  constructor (props: ICreatePasswordProps) {
+    super(props)
+    this.handleClick = this.handleClick.bind(this)
+  }
 
   state: ICreatePasswordState = {
     newPassword: '',
@@ -75,9 +81,9 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
           </Message>
 
           <Text>
-            <StyledButton onClick={this.handleClick.bind(this)}>
+            <Button onClick={this.handleClick}>
               {t('Create Account')}
-            </StyledButton>
+            </Button>
           </Text>
 
         </div>
@@ -98,7 +104,6 @@ type StateProps = ReturnType<typeof mapStateToProps>
 
 type DispatchProps = typeof mapDispatchToProps
 
-
 const Text = styled.p`
     width: 327px;
     margin:18px auto;
@@ -116,22 +121,6 @@ const Text = styled.p`
 const StyledPassword = styled.input`
   width: 311px;
   height: 42px;
-`
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
 `
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(CreatePassword))

--- a/src/ts/components/account/CreatePassword.tsx
+++ b/src/ts/components/account/CreatePassword.tsx
@@ -9,7 +9,7 @@ import { Message } from 'semantic-ui-react'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { GENERATE_PHRASE_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
-import { Button } from '../basic-components'
+import { Button, Section } from '../basic-components'
 
 interface ICreatePasswordProps extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -56,35 +56,35 @@ class CreatePassword extends React.Component<ICreatePasswordProps, ICreatePasswo
     return (
         <div>
           <Progress color={this.props.settings.color} progress={1} />
-          <Text>
+          <Section>
             {t('passwordDescription')}
-          </Text>
-          <Text>
+          </Section>
+          <Section>
             <StyledPassword
               type='password'
               placeholder={t('Create new password')}
               value={this.state.newPassword}
               onChange={evt => this.setState({ newPassword: evt.target.value })}/>
-          </Text>
+          </Section>
 
-          <Text>
+          <Section>
             <StyledPassword
               type='password'
               placeholder={t('Repeat password')}
               value={this.state.confirmPassword}
               onChange={evt => this.setState({ confirmPassword: evt.target.value })}
               />
-          </Text>
+          </Section>
 
           <Message negative={true} hidden={!this.state.errorMessage}>
             {this.state.errorMessage}
           </Message>
 
-          <Text>
+          <Section>
             <Button onClick={this.handleClick}>
               {t('Create Account')}
             </Button>
-          </Text>
+          </Section>
 
         </div>
     )
@@ -103,20 +103,6 @@ const mapDispatchToProps = { setLocked }
 type StateProps = ReturnType<typeof mapStateToProps>
 
 type DispatchProps = typeof mapDispatchToProps
-
-const Text = styled.p`
-    width: 327px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    color: #3e5860;
-`
 
 const StyledPassword = styled.input`
   width: 311px;

--- a/src/ts/components/account/GeneratePhrase.tsx
+++ b/src/ts/components/account/GeneratePhrase.tsx
@@ -9,7 +9,7 @@ import { Message, Container, Grid, Button, Icon } from 'semantic-ui-react'
 import { generateMnemonic } from '../../services/keyring-vault-proxy'
 import { setNewPhrase } from '../../background/store/account'
 import { CONFIRM_PHRASE_ROUTE } from '../../constants/routes'
-import { Button as StyledButton } from '../basic-components'
+import { Button as StyledButton, Section } from '../basic-components'
 
 interface IGeneratePhraseProps extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -80,14 +80,14 @@ class GeneratePhrase extends React.Component<IGeneratePhraseProps, IGeneratePhra
     return (
         <div>
           <Progress color={this.props.settings.color} progress={2} />
-          <Text>
+          <Section>
             {t('phraseDescription')}
-          </Text>
+          </Section>
 
-          <Text>
+          <Section>
             <div>{t('phraseTitle')}</div>
             <MnemonicPad value={this.state.mnemonic} readOnly={true} onClick={this.selectAll}/>
-          </Text>
+          </Section>
 
           <Message color={this.state.color} hidden={!this.state.message} style={alignMiddle}>
             {this.state.message}
@@ -112,11 +112,11 @@ class GeneratePhrase extends React.Component<IGeneratePhraseProps, IGeneratePhra
             </Grid>
           </Container>
 
-          <Text>
+          <Section>
             <StyledButton onClick={this.handleClick}>
               {t('createAccount')}
             </StyledButton>
-          </Text>
+          </Section>
 
         </div>
     )
@@ -136,19 +136,6 @@ type StateProps = ReturnType<typeof mapStateToProps>
 
 type DispatchProps = typeof mapDispatchToProps
 
-const Text = styled.div`
-    width: 327px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    color: #3e5860;
-`
 const MnemonicPad = styled.textarea`
   width: 311px;
   height: 125px;

--- a/src/ts/components/account/GeneratePhrase.tsx
+++ b/src/ts/components/account/GeneratePhrase.tsx
@@ -9,13 +9,14 @@ import { Message, Container, Grid, Button, Icon } from 'semantic-ui-react'
 import { generateMnemonic } from '../../services/keyring-vault-proxy'
 import { setNewPhrase } from '../../background/store/account'
 import { CONFIRM_PHRASE_ROUTE } from '../../constants/routes'
+import { Button as StyledButton } from '../basic-components'
 
 interface IGeneratePhraseProps extends StateProps, DispatchProps, RouteComponentProps {}
 
 interface IGeneratePhraseState {
   mnemonic: string,
   message?: string,
-  color: 'blue'|'red'
+  color: 'blue' | 'red'
 }
 
 class GeneratePhrase extends React.Component<IGeneratePhraseProps, IGeneratePhraseState> {
@@ -55,14 +56,14 @@ class GeneratePhrase extends React.Component<IGeneratePhraseProps, IGeneratePhra
     document.execCommand('copy')
     document.body.removeChild(el)
 
-    this.setState({message: t('copyTextMessage')})
-    setTimeout(()=> {
-      this.setState({message: ''})
+    this.setState({ message: t('copyTextMessage') })
+    setTimeout(() => {
+      this.setState({ message: '' })
     }, 3000)
   }
 
   downloadFile = () => {
-    var element = document.createElement('a');
+    let element = document.createElement('a')
     element.setAttribute('href',
         'data:text/plain;charset=utf-8,' + encodeURIComponent(this.state.mnemonic))
     element.setAttribute('download', 'secret-phrase.txt')
@@ -161,22 +162,7 @@ const MnemonicPad = styled.textarea`
   letter-spacing: normal;
   color: #30383b;
 `
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
-`
+
 const alignMiddle = {
   width: 311,
   margin: 'auto'

--- a/src/ts/components/account/GeneratePhrase.tsx
+++ b/src/ts/components/account/GeneratePhrase.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import styled from 'styled-components'
 import t from '../../services/i18n'
 import Progress from './Progress'
 import { IAppState } from '../../background/store/all'
@@ -9,7 +8,7 @@ import { Message, Container, Grid, Button, Icon } from 'semantic-ui-react'
 import { generateMnemonic } from '../../services/keyring-vault-proxy'
 import { setNewPhrase } from '../../background/store/account'
 import { CONFIRM_PHRASE_ROUTE } from '../../constants/routes'
-import { Button as StyledButton, Section } from '../basic-components'
+import { Button as StyledButton, Section, MnemonicPad } from '../basic-components'
 
 interface IGeneratePhraseProps extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -89,28 +88,31 @@ class GeneratePhrase extends React.Component<IGeneratePhraseProps, IGeneratePhra
             <MnemonicPad value={this.state.mnemonic} readOnly={true} onClick={this.selectAll}/>
           </Section>
 
-          <Message color={this.state.color} hidden={!this.state.message} style={alignMiddle}>
-            {this.state.message}
-          </Message>
+          <Section>
+            <Message color={this.state.color} hidden={!this.state.message}>
+              {this.state.message}
+            </Message>
+          </Section>
 
-          <Container style={alignMiddle}>
-            <Grid>
-              <Grid.Row columns={2}>
-                <Grid.Column>
-                  <Button onClick={this.copyText}>
-                    <Icon name='copy' />
-                    {t('copyText')}
-                  </Button>
-                </Grid.Column>
-
-                <Grid.Column>
-                  <Button onClick={this.downloadFile}>
-                    <Icon name='download' />
-                    {t('downloadFile')}</Button>
-                </Grid.Column>
-              </Grid.Row>
-            </Grid>
-          </Container>
+          <Section>
+            <Container>
+              <Grid>
+                <Grid.Row columns={2}>
+                  <Grid.Column>
+                    <Button onClick={this.copyText}>
+                      <Icon name='copy' />
+                      {t('copyText')}
+                    </Button>
+                  </Grid.Column>
+                  <Grid.Column>
+                    <Button onClick={this.downloadFile}>
+                      <Icon name='download' />
+                      {t('downloadFile')}</Button>
+                  </Grid.Column>
+                </Grid.Row>
+              </Grid>
+            </Container>
+          </Section>
 
           <Section>
             <StyledButton onClick={this.handleClick}>
@@ -135,24 +137,5 @@ const mapDispatchToProps = { setNewPhrase }
 type StateProps = ReturnType<typeof mapStateToProps>
 
 type DispatchProps = typeof mapDispatchToProps
-
-const MnemonicPad = styled.textarea`
-  width: 311px;
-  height: 125px;
-  font-family: Nunito;
-  padding: 10px;
-  font-size: 14px;
-  font-weight: normal;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.57;
-  letter-spacing: normal;
-  color: #30383b;
-`
-
-const alignMiddle = {
-  width: 311,
-  margin: 'auto'
-}
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(GeneratePhrase))

--- a/src/ts/components/account/Login.tsx
+++ b/src/ts/components/account/Login.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react'
-import styled from 'styled-components'
 import { RouteComponentProps, withRouter } from 'react-router'
 import { IAppState } from '../../background/store/all'
 import { connect } from 'react-redux'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { DEFAULT_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
-import { Button, Section, Title } from '../basic-components'
+import { Button, Section, Title, StyledPassword } from '../basic-components'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 
@@ -74,10 +73,5 @@ const mapStateToProps = (state: IAppState) => {
 const mapDispatchToProps = { setLocked }
 
 type DispatchProps = typeof mapDispatchToProps
-
-const StyledPassword = styled.input`
-  width: 311px;
-  height: 42px;
-`
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Login))

--- a/src/ts/components/account/Login.tsx
+++ b/src/ts/components/account/Login.tsx
@@ -6,7 +6,7 @@ import { connect } from 'react-redux'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { DEFAULT_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
-import { Button } from '../basic-components'
+import { Button, Section, Title } from '../basic-components'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 
@@ -48,18 +48,18 @@ class Login extends React.Component<ILoginProps, ILoginState> {
         <Title>
           login here
         </Title>
-        <Text>
+        <Section>
           <StyledPassword
             type='password'
             value={this.state.password}
             onChange={evt => this.setState({ password: evt.target.value })}
           />
-        </Text>
-        <Text>
+        </Section>
+        <Section>
           <Button onClick={this.handleLogin}>
             login
           </Button>
-        </Text>
+        </Section>
       </div>
     )
   }
@@ -78,29 +78,6 @@ type DispatchProps = typeof mapDispatchToProps
 const StyledPassword = styled.input`
   width: 311px;
   height: 42px;
-`
-
-const Text = styled.p`
-    width: 327px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    text-align: center;
-    color: #3e5860;
-`
-
-const Title = styled(Text)`
-    width: 311px;
-    height: 26px;
-    font-size: 19px;
-    font-weight: bold;
-    color: #30383B;
 `
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(Login))

--- a/src/ts/components/account/Login.tsx
+++ b/src/ts/components/account/Login.tsx
@@ -6,6 +6,7 @@ import { connect } from 'react-redux'
 import { unlockWallet } from '../../services/keyring-vault-proxy'
 import { DEFAULT_ROUTE } from '../../constants/routes'
 import { setLocked } from '../../background/store/account'
+import { Button } from '../basic-components'
 
 type StateProps = ReturnType<typeof mapStateToProps>
 
@@ -17,6 +18,11 @@ interface ILoginState {
 }
 
 class Login extends React.Component<ILoginProps, ILoginState> {
+
+  constructor (props: Readonly<ILoginProps>) {
+    super(props)
+    this.handleLogin = this.handleLogin.bind(this)
+  }
 
   state: ILoginState = {
     password: ''
@@ -50,9 +56,9 @@ class Login extends React.Component<ILoginProps, ILoginState> {
           />
         </Text>
         <Text>
-          <StyledButton onClick={this.handleLogin.bind(this)}>
+          <Button onClick={this.handleLogin}>
             login
-          </StyledButton>
+          </Button>
         </Text>
       </div>
     )
@@ -72,23 +78,6 @@ type DispatchProps = typeof mapDispatchToProps
 const StyledPassword = styled.input`
   width: 311px;
   height: 42px;
-`
-
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
 `
 
 const Text = styled.p`

--- a/src/ts/components/account/Login.tsx
+++ b/src/ts/components/account/Login.tsx
@@ -21,10 +21,15 @@ class Login extends React.Component<ILoginProps, ILoginState> {
   constructor (props: Readonly<ILoginProps>) {
     super(props)
     this.handleLogin = this.handleLogin.bind(this)
+    this.setPassword = this.setPassword.bind(this)
   }
 
   state: ILoginState = {
     password: ''
+  }
+
+  setPassword (event) {
+    this.setState({ password: event.target.value })
   }
 
   handleLogin () {
@@ -51,7 +56,7 @@ class Login extends React.Component<ILoginProps, ILoginState> {
           <StyledPassword
             type='password'
             value={this.state.password}
-            onChange={evt => this.setState({ password: evt.target.value })}
+            onChange={this.setPassword}
           />
         </Section>
         <Section>

--- a/src/ts/components/account/Term.tsx
+++ b/src/ts/components/account/Term.tsx
@@ -6,7 +6,7 @@ import { IAppState } from '../../background/store/all'
 import { connect } from 'react-redux'
 import { saveSettings } from '../../background/store/settings'
 import { RouteComponentProps, withRouter } from 'react-router'
-import { Button } from '../basic-components'
+import { Button, Section, Title } from '../basic-components'
 
 interface ITermProp extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -24,44 +24,22 @@ class Term extends React.Component<ITermProp> {
           <Title>
             {t('termTitle')}
           </Title>
-          <TermText>
+          <TermSection>
             {t('termDescription')}
-          </TermText>
-          <Text>
+          </TermSection>
+          <Section>
             <Button onClick={this.handleClick}>
               {t('termAcceptButton')}
             </Button>
-          </Text>
+          </Section>
         </div>
     )
   }
 }
 
-const Text = styled.p`
-    width: 311px;
-    margin:18px auto;
-    opacity: 0.6;
-    font-family: Nunito;
-    font-size: 14px;
-    font-weight: normal;
-    font-style: normal;
-    font-stretch: normal;
-    line-height: normal;
-    letter-spacing: normal;
-    color: #3e5860;
-`
-
-const Title = styled(Text)`
-    width: 311px;
-    height: 26px;
-    font-size: 19px;
-    font-weight: bold;
-    color: #30383B;
-`
-const TermText = styled(Text)`
+const TermSection = styled(Section)`
   height: 347px;
   overflow-y: auto;
-
 `
 
 const mapStateToProps = (state: IAppState) => {

--- a/src/ts/components/account/Term.tsx
+++ b/src/ts/components/account/Term.tsx
@@ -6,6 +6,7 @@ import { IAppState } from '../../background/store/all'
 import { connect } from 'react-redux'
 import { saveSettings } from '../../background/store/settings'
 import { RouteComponentProps, withRouter } from 'react-router'
+import { Button } from '../basic-components'
 
 interface ITermProp extends StateProps, DispatchProps, RouteComponentProps {}
 
@@ -27,9 +28,9 @@ class Term extends React.Component<ITermProp> {
             {t('termDescription')}
           </TermText>
           <Text>
-            <StyledButton onClick={this.handleClick}>
+            <Button onClick={this.handleClick}>
               {t('termAcceptButton')}
-            </StyledButton>
+            </Button>
           </Text>
         </div>
     )
@@ -61,22 +62,6 @@ const TermText = styled(Text)`
   height: 347px;
   overflow-y: auto;
 
-`
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
 `
 
 const mapStateToProps = (state: IAppState) => {

--- a/src/ts/components/basic-components.ts
+++ b/src/ts/components/basic-components.ts
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+
+export const LayoutContainer = styled('div')`
+    width: 375px;
+    height: 667px;
+    border-radius: 4px;
+    box-shadow: 0 6px 30px 0 ${props => props.theme.shadowColor};
+    border: solid 1px ${props => props.theme.borderColor};
+    background-color: ${props => props.theme.backgroundColor};
+`
+
+export const Button = styled.button`
+  width: 311px;
+  height: 45px;
+  border-radius: 4px;
+  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
+  background-color: #24b6e8;
+  font-family: Nunito;
+  font-size: 16px;
+  font-weight: 800;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.31;
+  letter-spacing: normal;
+  text-align: center;
+  color: #ffffff;
+`

--- a/src/ts/components/basic-components.ts
+++ b/src/ts/components/basic-components.ts
@@ -26,7 +26,7 @@ export const Button = styled.button`
   color: #ffffff;
 `
 
-export const Section = styled.p`
+export const Section = styled.div`
     width: 327px;
     margin:18px auto;
     opacity: 0.6;

--- a/src/ts/components/basic-components.ts
+++ b/src/ts/components/basic-components.ts
@@ -1,20 +1,5 @@
 import styled from 'styled-components'
 
-export const AppContainer = styled('div')`
-    position: absolute;
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    justify-items: center;
-    align-items: center;
-    height: 90vh;
-    width: 90vw;
-    left: 5vw;
-    top: 5vh;
-    background-color: ${p => p.theme.backgroundColor};
-    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
-`
-
 export const LayoutContainer = styled('div')`
     width: 375px;
     height: 667px;

--- a/src/ts/components/basic-components.ts
+++ b/src/ts/components/basic-components.ts
@@ -1,5 +1,20 @@
 import styled from 'styled-components'
 
+export const AppContainer = styled('div')`
+    position: absolute;
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    justify-items: center;
+    align-items: center;
+    height: 90vh;
+    width: 90vw;
+    left: 5vw;
+    top: 5vh;
+    background-color: ${p => p.theme.backgroundColor};
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+`
+
 export const LayoutContainer = styled('div')`
     width: 375px;
     height: 667px;
@@ -24,4 +39,41 @@ export const Button = styled.button`
   letter-spacing: normal;
   text-align: center;
   color: #ffffff;
+`
+
+export const Section = styled.p`
+    width: 327px;
+    margin:18px auto;
+    opacity: 0.6;
+    font-family: Nunito;
+    font-size: 14px;
+    font-weight: normal;
+    font-style: normal;
+    font-stretch: normal;
+    line-height: normal;
+    letter-spacing: normal;
+    text-align: center;
+    color: #3e5860;
+`
+
+export const Title = styled(Section)`
+    width: 311px;
+    height: 26px;
+    font-size: 19px;
+    font-weight: bold;
+    color: #30383B;
+`
+
+export const MnemonicPad = styled.textarea`
+  width: 311px;
+  height: 125px;
+  font-family: Nunito;
+  padding: 10px;
+  font-size: 14px;
+  font-weight: normal;
+  font-style: normal;
+  font-stretch: normal;
+  line-height: 1.57;
+  letter-spacing: normal;
+  color: #30383b;
 `

--- a/src/ts/components/basic-components.ts
+++ b/src/ts/components/basic-components.ts
@@ -62,3 +62,8 @@ export const MnemonicPad = styled.textarea`
   letter-spacing: normal;
   color: #30383b;
 `
+
+export const StyledPassword = styled.input`
+  width: 311px;
+  height: 42px;
+`

--- a/src/ts/components/dashboard/Dashboard.tsx
+++ b/src/ts/components/dashboard/Dashboard.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import { lockWallet } from '../../services/keyring-vault-proxy'
 import { UNLOCK_ROUTE } from '../../constants/routes'
 import { RouteComponentProps, withRouter } from 'react-router'
+import { Button } from '../basic-components'
 
 interface IDashboardProp extends RouteComponentProps {}
 
@@ -23,9 +24,9 @@ class Dashboard extends React.Component<IDashboardProp> {
           Dashboard goes here
         </Title>
         <Text>
-          <StyledButton onClick={this.handleClick}>
+          <Button onClick={this.handleClick}>
             Logout
-          </StyledButton>
+          </Button>
         </Text>
       </div>
     )
@@ -53,20 +54,5 @@ const Title = styled(Text)`
     font-weight: bold;
     color: #30383B;
 `
-const StyledButton = styled.button`
-  width: 311px;
-  height: 45px;
-  border-radius: 4px;
-  box-shadow: 0 3px 10px 0 rgba(72, 178, 228, 0.21);
-  background-color: #24b6e8;
-  font-family: Nunito;
-  font-size: 16px;
-  font-weight: 800;
-  font-style: normal;
-  font-stretch: normal;
-  line-height: 1.31;
-  letter-spacing: normal;
-  text-align: center;
-  color: #ffffff;
-`
+
 export default withRouter(Dashboard)

--- a/src/ts/components/dashboard/Dashboard.tsx
+++ b/src/ts/components/dashboard/Dashboard.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { lockWallet } from '../../services/keyring-vault-proxy'
 import { UNLOCK_ROUTE } from '../../constants/routes'
 import { RouteComponentProps, withRouter } from 'react-router'
-import { Button } from '../basic-components'
+import { Button, Section } from '../basic-components'
 
 interface IDashboardProp extends RouteComponentProps {}
 
@@ -23,11 +23,11 @@ class Dashboard extends React.Component<IDashboardProp> {
         <Title>
           Dashboard goes here
         </Title>
-        <Text>
+        <Section>
           <Button onClick={this.handleClick}>
             Logout
           </Button>
-        </Text>
+        </Section>
       </div>
     )
   }

--- a/src/ts/components/styles/styled-components.ts
+++ b/src/ts/components/styles/styled-components.ts
@@ -2,7 +2,9 @@ import 'styled-components'
 // Enhance the DefaultTheme interface with new attributes.
 // While still importing the DefaultTheme interface from styled-components.
 declare module 'styled-components' {
-export interface DefaultTheme {
-  backgroundColor: string
-}
+  export interface DefaultTheme {
+    backgroundColor: string,
+    shadowColor: string,
+    borderColor: string
+  }
 }

--- a/src/ts/components/styles/themes/index.ts
+++ b/src/ts/components/styles/themes/index.ts
@@ -3,11 +3,15 @@ import { DefaultTheme } from 'styled-components'
 export type ThemeTypes = 'light' | 'dark'
 
 export const lightTheme: DefaultTheme = {
-  backgroundColor: '#ffffff'
+  backgroundColor: '#ffffff',
+  shadowColor: 'rgba(0, 0, 0, 0.08)',
+  borderColor: '#e7e7e7'
 }
 
 export const darkTheme: DefaultTheme = {
-  backgroundColor: '#181818'
+  backgroundColor: '#181818',
+  shadowColor: 'rgba(0, 0, 0, 0.7)',
+  borderColor: '#121212'
 }
 
 export const themes = {

--- a/src/ts/contentScripts/extension/containers/SpeckleApp.tsx
+++ b/src/ts/contentScripts/extension/containers/SpeckleApp.tsx
@@ -15,13 +15,13 @@ class SpeckleApp extends React.Component<ISpeckleApp> {
 
   render () {
     return (
-            <ThemeProvider theme={themes[this.props.theme]}>
-                <React.Fragment>
-                    <SpeckleAppContainer >
-                        <App />
-                    </SpeckleAppContainer>
-                </React.Fragment>
-            </ThemeProvider>
+      <ThemeProvider theme={themes[this.props.theme]}>
+        <React.Fragment>
+          <SpeckleAppContainer>
+            <App/>
+          </SpeckleAppContainer>
+        </React.Fragment>
+      </ThemeProvider>
     )
   }
 }

--- a/src/ts/layouts/DashboardLayout.tsx
+++ b/src/ts/layouts/DashboardLayout.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
 import Image from 'semantic-ui-react/dist/commonjs/elements/Image/Image'
 import { IAppState } from '../background/store/all'
+import { LayoutContainer } from '../components/basic-components'
 
 interface ILoginLayoutProp extends StateProps, DispatchProps {}
 
@@ -18,22 +18,13 @@ class DashboardLayout extends Component<ILoginLayoutProp, ILoginLayoutState> {
 
   render () {
     return (
-      <DashboardStyleContainer>
+      <LayoutContainer>
         <Image src={this.getBackgroundImageUrl()} />
         {this.props.children}
-      </DashboardStyleContainer>
+      </LayoutContainer>
     )
   }
 }
-
-const DashboardStyleContainer = styled('div')`
-    width: 375px;
-    height: 667px;
-    border-radius: 4px;
-    box-shadow: 0 6px 30px 0 rgba(0, 0, 0, 0.08);
-    border: solid 1px #e7e7e7;
-    background-color: #ffffff;
-`
 
 const mapStateToProps = (state: IAppState) => {
   return {

--- a/src/ts/layouts/LoginLayout.tsx
+++ b/src/ts/layouts/LoginLayout.tsx
@@ -1,8 +1,8 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
-import styled from 'styled-components'
 import Image from 'semantic-ui-react/dist/commonjs/elements/Image/Image'
 import { IAppState } from '../background/store/all'
+import { LayoutContainer } from '../components/basic-components'
 
 interface ILoginLayoutProp extends StateProps, DispatchProps {}
 
@@ -14,22 +14,13 @@ class LoginLayout extends Component<ILoginLayoutProp> {
 
   render () {
     return (
-    <LoginStyleContainer>
+    <LayoutContainer>
       <Image src={this.getHeaderImageUrl()} />
       {this.props.children}
-    </LoginStyleContainer>
+    </LayoutContainer>
     )
   }
 }
-
-const LoginStyleContainer = styled('div')`
-    width: 375px;
-    height: 667px;
-    border-radius: 4px;
-    box-shadow: 0 6px 30px 0 rgba(0, 0, 0, 0.08);
-    border: solid 1px #e7e7e7;
-    background-color: #ffffff;
-`
 
 const mapStateToProps = (state: IAppState) => {
   return {

--- a/src/ts/options/containers/OptionsApp.tsx
+++ b/src/ts/options/containers/OptionsApp.tsx
@@ -16,14 +16,14 @@ class OptionsApp extends React.Component<IOptionsApp> {
 
   render () {
     return (
-            <ThemeProvider theme={themes[this.props.theme]}>
-                <React.Fragment>
-                    <GlobalStyle />
-                    <OptionsAppContainer>
-                        <App/>
-                    </OptionsAppContainer>
-                </React.Fragment>
-            </ThemeProvider>
+      <ThemeProvider theme={themes[this.props.theme]}>
+        <React.Fragment>
+          <GlobalStyle/>
+          <OptionsAppContainer>
+            <App/>
+          </OptionsAppContainer>
+        </React.Fragment>
+      </ThemeProvider>
     )
   }
 }

--- a/src/ts/popup/containers/PopupApp.tsx
+++ b/src/ts/popup/containers/PopupApp.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react'
 import { connect } from 'react-redux'
 import styled, { ThemeProvider } from 'styled-components'
+import { HashRouter as Router } from 'react-router-dom'
 import { IAppState } from '../../background/store/all'
 
 import GlobalStyle from '../../components/styles/GlobalStyle'
 import { themes } from '../../components/styles/themes'
-import { HashRouter as Router } from 'react-router-dom'
 import { Routes } from '../../routes'
 import { getSettings } from '../../background/store/settings'
 import { isWalletLocked } from '../../services/keyring-vault-proxy'


### PR DESCRIPTION
I did initial refactoring -- put those reusable styled components in one place for reuse. It's tested.

But there seems to be a lot more to do:
1. We probably need to turn `color` in IAppSettings into `colorScheme` object which includes colors to render the button, etc and the styled buttons will need to read those colors dynamically.
2. We repeat 311px 327px many times in different components. We probably come up with a simpler box model, e.g, a 311px wide container for everything in it. that way, when we change the width, we change one place.

Since there are already a lot of changes, I'll leave those changes for next pull request 